### PR TITLE
Version 1.0.3

### DIFF
--- a/lib/subfork/client.py
+++ b/lib/subfork/client.py
@@ -275,7 +275,7 @@ class SubforkWsClient:
         """
         self.http_client = http_client
         self.url = url.rstrip("/")
-        self._sio = socketio.Client(reconnection=True)
+        self._sio = socketio.Client(reconnection=False)
         self._connect_lock = threading.Lock()
         self._connected = False
         self._connecting = False

--- a/lib/subfork/client.py
+++ b/lib/subfork/client.py
@@ -88,6 +88,7 @@ class SubforkHttpClient(object):
             "token": None,
             "user-agent": f"python-{__prog__}/{__version__}",
         }
+        self._session_lock = threading.Lock()
         self.check_config()
         self.get_session_data()
 
@@ -219,35 +220,36 @@ class SubforkHttpClient(object):
                 raise RequestError(status_message)
         return None
 
-    def get_session_data(self):
+    def get_session_data(self, refresh: bool = False):
         """Requests and returns session data from remote server."""
-        if self.session:
+        with self._session_lock:
+            if self.session and not refresh:
+                return self.session
+            self.session = self._request(
+                "session",
+                data={
+                    "source": "python-client",
+                    "version": util.get_version(),
+                },
+            )
+            if self.session and self.session.get("sessionid"):
+                self.sessionid = str(self.session["sessionid"])
+            else:
+                raise ConnectError("could not get session data")
+            if self.session and self.session.get("token"):
+                self.token = self.session.get("token")
+            else:
+                raise ConnectError("could not get session data")
+            self.headers.update(
+                {
+                    "sid": self.sessionid,
+                    "Authorization": f"Bearer {self.token}",
+                    "user-agent": f"subfork-python/{__version__}",
+                    "x-client": "subfork-python",
+                    "x-client-version": __version__,
+                }
+            )
             return self.session
-        self.session = self._request(
-            "session",
-            data={
-                "source": "python-client",
-                "version": util.get_version(),
-            },
-        )
-        if self.session and self.session.get("sessionid"):
-            self.sessionid = str(self.session["sessionid"])
-        else:
-            raise ConnectError("could not get session data")
-        if self.session and self.session.get("token"):
-            self.token = self.session.get("token")
-        else:
-            raise ConnectError("could not get session data")
-        self.headers.update(
-            {
-                "sid": self.sessionid,
-                "Authorization": f"Bearer {self.token}",
-                "user-agent": f"subfork-python/{__version__}",
-                "x-client": "subfork-python",
-                "x-client-version": __version__,
-            }
-        )
-        return self.session
 
     def get_session_token(self):
         """Return the session id for with the current connection."""
@@ -278,35 +280,6 @@ class SubforkWsClient:
         self._connected = False
         self._connecting = False
 
-        # get session data
-        sid = self.http_client.get_session_token()
-        token = None
-        if self.http_client.session:
-            token = self.http_client.session.get("token")
-
-        if not sid:
-            raise ConnectError(
-                "No session id available; ensure get_session_data() succeeded."
-            )
-        if not token:
-            raise ConnectError(
-                "No token available; ensure get_session_data() succeeded."
-            )
-
-        # default headers
-        headers = {
-            "sid": sid,
-            "Authorization": f"Bearer {token}",
-            "user-agent": self.http_client.headers.get("user-agent", "subfork-python"),
-        }
-        self._connect_kwargs = {
-            "headers": headers,
-            "auth": {"token": token},
-            "socketio_path": config.SOCKETIO_PATH,
-            "transports": ["websocket"],
-        }
-
-        # lifecycle hooks
         @self._sio.event
         def connect():
             with self._connect_lock:
@@ -321,6 +294,29 @@ class SubforkWsClient:
 
     def __repr__(self):
         return "<SubforkWsClient %s>" % self.url
+
+    def _build_connect_kwargs(self):
+        """Builds connection kwargs for Socket.IO connect()."""
+        self.http_client.get_session_data(refresh=True)
+
+        sid = self.http_client.get_session_token()
+        token = (
+            self.http_client.session.get("token") if self.http_client.session else None
+        )
+        if not sid or not token:
+            raise ConnectError("missing sid/token; cannot connect")
+
+        headers = {
+            "sid": sid,
+            "Authorization": f"Bearer {token}",
+            "user-agent": self.http_client.headers.get("user-agent", "subfork-python"),
+        }
+        return {
+            "headers": headers,
+            "auth": {"token": token},
+            "socketio_path": config.SOCKETIO_PATH,
+            "transports": ["websocket"],
+        }
 
     def close(self):
         """Close the WebSocket connection."""
@@ -338,7 +334,8 @@ class SubforkWsClient:
                 return
             self._connecting = True
         try:
-            self._sio.connect(self.url, **self._connect_kwargs)
+            connect_kwargs = self._build_connect_kwargs()
+            self._sio.connect(self.url, **connect_kwargs)
         except socketio.exceptions.ConnectionError as e:
             log.error("SubforkWsClient connection error: %s", e)
         except Exception as e:

--- a/lib/subfork/threads.py
+++ b/lib/subfork/threads.py
@@ -139,10 +139,8 @@ class HealthCheck(StoppableThread):
                 "vms": util.b2h(samp["process"]["memory"]["vms"]),
             }
             msg = "cpu:{cpu}% rss:{rss} vms:{vms} runtime:{runtime}".format(**kwargs)
-            if runtime % 3600:
+            if kwargs["cpu"] > 80:
                 log.debug(msg)
-            else:
-                log.info(msg)
 
 
 class WsPump(StoppableThread):
@@ -158,26 +156,35 @@ class WsPump(StoppableThread):
         self.wait_time = wait_time
 
     def run(self):
-        backoff = float(self.wait_time or 1)
+        """Called when thread starts."""
+        base = float(self.wait_time or 1)
+        backoff = base
 
         while not self.stopped():
+            connected_at = None
             try:
                 ws = self.client.ws()
 
-                # idempotent connect: safe even if already connected
                 if not ws.is_connected():
                     log.debug("ws_pump: connecting to events server...")
                     ws.connect()
 
-                log.debug("ws_pump: wait()")
-                ws.wait()  # blocks until disconnect / error
+                # if connect succeeded, reset backoff immediately
+                if ws.is_connected():
+                    backoff = base
+                    connected_at = time.time()
 
-                # if wait() returns, treat as disconnect and retry.
+                log.debug("ws_pump: wait()")
+                ws.wait()
+
                 log.warning("ws_pump: disconnected (wait() returned)")
             except Exception as e:
                 log.warning("ws_pump: exception: %s", e)
 
-            # backoff + jitter (cap at 30s)
+            # reset backoff after a successful connection for 30+ seconds
+            if connected_at and (time.time() - connected_at) > 30:
+                backoff = base
+
             sleep_s = min(30.0, backoff) + random.random()
             log.debug("ws_pump: retrying in %.1fs", sleep_s)
             time.sleep(sleep_s)

--- a/lib/subfork/version.py
+++ b/lib/subfork/version.py
@@ -7,4 +7,4 @@
 #
 
 __prog__ = "subfork"
-__version__ = "1.0.2"
+__version__ = "1.0.3"

--- a/lib/subfork/version.py
+++ b/lib/subfork/version.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python33
+#!/usr/bin/env python3
 #
 # Copyright (c) Subfork. All rights reserved.
 #

--- a/lib/subfork/worker.py
+++ b/lib/subfork/worker.py
@@ -97,10 +97,14 @@ class Worker(threads.StoppableThread):
         # attach event handler and attempt initial connect
         self.client.ws().on(self.created_event, handler=self.on_task_created)
 
+        start = time.time()
+        grace = 5.0  # seconds
+
         # main loop: if WS disconnected, poll; otherwise sleep
         while not self.stopped():
             if not self.client.ws().is_connected():
-                log.debug("socket failed, polling queue: %s", self.queue.name)
+                if time.time() - start > grace:
+                    log.debug("socket failed, polling queue: %s", self.queue.name)
                 self.process_tasks()
             self._stop_event.wait(self.wait_time)
 
@@ -451,9 +455,6 @@ def run_workers(
 
     # total worker thread counter
     worker_count = 0
-
-    # establish client websocket connection
-    client.ws().connect()
 
     # iterate through worker configs and start workers
     for config_name, worker_config in worker_configs.items():

--- a/lib/subfork/worker.py
+++ b/lib/subfork/worker.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python33
+#!/usr/bin/env python3
 #
 # Copyright (c) Subfork. All rights reserved.
 #


### PR DESCRIPTION
This pull request introduces several improvements to the Subfork client library, focusing on thread safety for session management, more robust WebSocket connection handling, and enhanced logging for monitoring and debugging. The changes also include minor bug fixes and version updates.

**Session and WebSocket Connection Handling:**

* Added a thread lock (`_session_lock`) to the Subfork client to ensure thread-safe access to session data, preventing potential race conditions when multiple threads request session updates.
* Refactored session retrieval logic to support forced refreshes and moved connection argument construction into a dedicated method (`_build_connect_kwargs`), improving clarity and ensuring fresh session tokens are used for each WebSocket connection attempt. [[1]](diffhunk://#diff-b5acb41b9f4b23d491a2426c1cf6e8eb70a743dfb64e8df2fec3b189ad277fd8L222-R226) [[2]](diffhunk://#diff-b5acb41b9f4b23d491a2426c1cf6e8eb70a743dfb64e8df2fec3b189ad277fd8L276-L309) [[3]](diffhunk://#diff-b5acb41b9f4b23d491a2426c1cf6e8eb70a743dfb64e8df2fec3b189ad277fd8R298-R320) [[4]](diffhunk://#diff-b5acb41b9f4b23d491a2426c1cf6e8eb70a743dfb64e8df2fec3b189ad277fd8L341-R338)

**Thread Behavior and Backoff Logic:**

* Improved the `WsPump` thread logic to reset connection backoff after a successful connection lasting more than 30 seconds, and clarified connection retry behavior for more reliable event streaming.

**Logging and Monitoring:**

* Adjusted CPU usage logging in the `MonitorThread` to log debug messages only when CPU usage exceeds 80%, reducing log noise and focusing attention on high-load scenarios.
* Added a startup grace period to the worker polling logic, suppressing noisy logs during initial connection attempts.

**Miscellaneous Fixes:**

* Fixed shebang lines in `version.py` and `worker.py` to use Python 3 correctly, and updated the package version to `1.0.3`. [[1]](diffhunk://#diff-2cb98aae34d1f96d1082035f39de80693f533488039ca5a5951623ed171ad642L1-R1) [[2]](diffhunk://#diff-2cb98aae34d1f96d1082035f39de80693f533488039ca5a5951623ed171ad642L10-R10) [[3]](diffhunk://#diff-8e11e5a6b359e8513a8bb9824dab84db234722816f3eed6ae3b58a00984d6371L1-R1)

**Other:**

* Removed an unnecessary early connection attempt in the worker startup sequence to streamline initialization.